### PR TITLE
feat: multi line notes

### DIFF
--- a/src/popup.rs
+++ b/src/popup.rs
@@ -70,10 +70,9 @@ impl Popup {
         let save_button = gtk::Button::new_with_label("Start Timer");
         save_button.set_can_default(true);
         let notes_input = gtk::TextView::new();
-        notes_input
-            .set_border_width(4);
-        notes_input
-            .set_wrap_mode(gtk::WrapMode::WordChar);
+        notes_input.set_border_width(4);
+        notes_input.set_wrap_mode(gtk::WrapMode::WordChar);
+        notes_input.set_accepts_tab(false);
         let hours_input = gtk::Entry::new();
         hours_input
             .set_property("activates-default", &true)
@@ -166,7 +165,8 @@ impl Popup {
 
         self.window.add(&grid);
 
-        let scrollable_window = gtk::ScrolledWindow::new(gtk::NONE_ADJUSTMENT, gtk::NONE_ADJUSTMENT);
+        let scrollable_window =
+            gtk::ScrolledWindow::new(gtk::NONE_ADJUSTMENT, gtk::NONE_ADJUSTMENT);
         scrollable_window.set_policy(gtk::PolicyType::Automatic, gtk::PolicyType::Automatic);
         scrollable_window.add(&self.notes_input);
         scrollable_window.set_shadow_type(gtk::ShadowType::Out);
@@ -179,7 +179,7 @@ impl Popup {
         self.delete_button.set_sensitive(false);
         grid.attach(&self.delete_button, 0, 9, 1, 2);
 
-        grid.attach(&self.save_button, 1, 9, 1,2);
+        grid.attach(&self.save_button, 1, 9, 1, 2);
         self.save_button.grab_default();
 
         grid.set_column_homogeneous(true);
@@ -213,7 +213,14 @@ impl Popup {
                             .send(app::Signal::StartTimer(
                                 project_id,
                                 task_id,
-                                notes_buffer.get_text(&notes_buffer.get_start_iter(), &notes_buffer.get_end_iter(), false).unwrap().to_string(),
+                                notes_buffer
+                                    .get_text(
+                                        &notes_buffer.get_start_iter(),
+                                        &notes_buffer.get_end_iter(),
+                                        false,
+                                    )
+                                    .unwrap()
+                                    .to_string(),
                                 duration_str_to_f32(&hours_input.get_text().unwrap()),
                             ))
                             .expect("Sending message to background thread");
@@ -225,7 +232,14 @@ impl Popup {
                                 id,
                                 project_id,
                                 task_id,
-                                notes_buffer.get_text(&notes_buffer.get_start_iter(), &notes_buffer.get_end_iter(), false).unwrap().to_string(),
+                                notes_buffer
+                                    .get_text(
+                                        &notes_buffer.get_start_iter(),
+                                        &notes_buffer.get_end_iter(),
+                                        false,
+                                    )
+                                    .unwrap()
+                                    .to_string(),
                                 duration_str_to_f32(&hours_input.get_text().unwrap()),
                             ))
                             .expect("Sending message to background thread");

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -215,12 +215,26 @@ impl Ui {
             total_hours += time_entry.hours;
 
             let notes = match time_entry.notes.as_ref() {
-                Some(n) => n
-                    .replace("&", "&amp;")
-                    .replace("<", "&lt;")
-                    .replace(">", "&gt;"),
+                Some(n) => {
+                    let formatted: String = n
+                        .replace("&", "&amp;")
+                        .replace("<", "&lt;")
+                        .replace(">", "&gt;")
+                        .replace("\n\n", "\n")
+                        .replace("\n", " - ")
+                        .chars()
+                        .take(80)
+                        .collect();
+
+                    if n.chars().count() > 80 {
+                        formatted.clone() + "..."
+                    } else {
+                        formatted
+                    }
+                },
                 None => "".to_string(),
             };
+
             let project_client = format!(
                 "<b>{}</b> ({})\n{} - {}",
                 &time_entry.project.name_and_code(),


### PR DESCRIPTION
Added multi line notes for time entries

+ placeholder for time input (to know what to enter)
+ extended the formatting of the time entry in the day view - max 80 chars of the notes and make single line

PS: Nice project! (i had the idea to greate an own time tracking app for harvest, but why not working at one :))
PPS: This is the first time i am doing anything with rust and gtk - please be kind :D

Sadly gtk is a little bit strange to work with. (i tried to add the gtk::Entry css classes to the textview to get the round borders and background colors, but no luck, or just adding placeholders for the comboboxes and textview). Even the grid behaves/works a little bit strange, if you are coming from web dev.