### PR TITLE
Make link clickable inside new version notice

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -239,9 +239,10 @@ impl App {
                     if current_version < latest_version {
                         self.to_ui
                             .send(ui::Signal::ShowNotice(format!(
-                                "New version available ({}), download it from {}",
+                                "New version available ({}), download it from <a href=\"{}\">{}</a>",
                                 txt.data.dname,
                                 env!("CARGO_PKG_HOMEPAGE"),
+                                env!("CARGO_PKG_HOMEPAGE")
                             )))
                             .expect("Sending message to ui thread");
                         break;

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -139,10 +139,13 @@ impl Ui {
                 Signal::ShowNotice(message) => {
                     let bar = gtk::InfoBar::new();
                     let content_area = bar.get_content_area().unwrap();
+                    let label = gtk::Label::new(None);
+                    label.set_markup(&message);
+
                     content_area
                         .downcast::<gtk::Container>()
                         .unwrap()
-                        .add(&gtk::Label::new(Some(&message)));
+                        .add(&label);
                     bar.show_all();
                     ui.grid.attach(&bar, 0, 0, 4, 1);
                 }


### PR DESCRIPTION
The reason behind this one is that every time there's a new version I have to find the repo manually and now one can just click on the link inside the notice.